### PR TITLE
Check if parent exists before accessing name

### DIFF
--- a/scripts/apps/helpers.js
+++ b/scripts/apps/helpers.js
@@ -213,7 +213,7 @@ export function damageToWorkflowData(d, change, diff){
             scene: canvas.scene.id, 
             actor: d.id,
             token: canvas.scene.tokens.find(t => t.actor && t.actor?.id === d.id)?.id, 
-            alias: d.parent.name
+            alias: d.parent ? d.parent.name : d.name
         },
         diff: hpDiff,
     }


### PR DESCRIPTION
This should address #142 

The original bug is triggered by Link Actor Data being checked in the Token settings dialog. Note to self make sure to add this scenario to testing. 